### PR TITLE
<fix> TABLE NAME 그대로 유지되도록 Backtik 추가

### DIFF
--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ConcertJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ConcertJpaEntity.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
-@Table(name = "CONCERT")
+@Table(name = "'CONCERT'")
 @Getter
 public class ConcertJpaEntity extends BaseJpaEntity{
 

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ConcertScheduleJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ConcertScheduleJpaEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Entity
-@Table(name = "CONCERTSCHEDULE"
+@Table(name = "'CONCERTSCHEDULE'"
         , indexes = @Index(name = "IDX_RESERVATION_AVAILABLE_PERIOD", columnList = "reservationStartAt, reservationEndAt"))
 @Getter
 public class ConcertScheduleJpaEntity extends BaseJpaEntity{

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/PointHistoryJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/PointHistoryJpaEntity.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "POINTHISTORY")
+@Table(name = "'POINTHISTORY'")
 public class PointHistoryJpaEntity {
 
     @Id

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ReservationJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/ReservationJpaEntity.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "RESERVATION")
+@Table(name = "'RESERVATION'")
 public class ReservationJpaEntity extends BaseJpaEntity{
 
     @Id

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/SeatJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/SeatJpaEntity.java
@@ -11,7 +11,7 @@ import java.util.List;
 import lombok.Getter;
 
 @Entity
-@Table(name = "SEAT", indexes = {
+@Table(name = "'SEAT'", indexes = {
         @Index(name = "IDX_SEAT_CONCERT_SCHEDULE_ID", columnList = "concertScheduleId")
 })
 @Getter

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/TokenJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/TokenJpaEntity.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "QUEUE")
+@Table(name = "'QUEUE'")
 @Getter
 public class TokenJpaEntity extends BaseJpaEntity {
 

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/UserJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/UserJpaEntity.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "USER")
+@Table(name = "'USER'")
 @Getter
 @NoArgsConstructor
 public class UserJpaEntity extends BaseJpaEntity {

--- a/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/UserPointBalanceJpaEntity.java
+++ b/src/main/java/com/slam/concertreservation/infrastructure/persistence/jpa/entities/UserPointBalanceJpaEntity.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "POINTBALANCE")
+@Table(name = "'POINTBALANCE'")
 public class UserPointBalanceJpaEntity extends BaseJpaEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
 - MySQL의 'lower_case_table_names' row 수가 0임을 확인 -> MySQL 에서는 대소문자 구분을 한다는 것.
 - 하지만 APP 실행 시 빈 초기화 과정에서 hibernate 가 소문자 이름인 'concert' 테이블을 찾아다님 -> 그러나 DDL 명세시 USER 테이블을 의식하여 모두 Backtik 을 DDL 에 명시했기 때문에 MySQL 은 Case-sensitive 하게 테이블을 생성. => 그래서 테이블을 못 찾은 것!